### PR TITLE
Use JDK Ed25519 signature

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sshd</groupId>
         <artifactId>sshd</artifactId>
-        <version>2.15.1-SNAPSHOT</version>
+        <version>2.15.88-SNAPSHOT</version>
     </parent>
 
     <artifactId>apache-sshd</artifactId>

--- a/java-native-ed25519.md
+++ b/java-native-ed25519.md
@@ -1,0 +1,69 @@
+# Native
+
+
+## Master files net.i2p
+
+
+## Public Key Decoder
+
+    sshd-common/src/main/java/org/apache/sshd/common/util/buffer/keys/SkED25519BufferPublicKeyParser.java
+                 |  ↓  |
+    sshd-common/src/main/java/org/apache/sshd/common/config/keys/impl/SkED25519PublicKeyEntryDecoder.java
+     ↓  |     |  |     ↓
+    sshd-common/src/main/java/org/apache/sshd/common/config/keys/u2f/SkED25519PublicKey.java
+        ↓  |  |  |
+    sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/Ed25519PublicKeyDecoder.java
+     ↓     ↓  ↓  ↓
+    net.i2p.crypto.eddsa.EdDSAPublicKey
+
+
+### Constant Only
+
+    sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/SignatureEd25519.java
+## ..
+
+    sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/Ed25519PEMResourceKeyParser.java
+    sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/EdDSASecurityProviderRegistrar.java
+    sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/EdDSASecurityProviderUtils.java
+    sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/OpenSSHEd25519PrivateKeyEntryDecoder.java
+
+**sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/SignatureEd25519.java**
+
+        super(EdDSAEngine.SIGNATURE_ALGORITHM);
+
+
+### Test
+
+    sshd-cli/src/test/java/org/apache/sshd/cli/SshKeyDumpMain.java
+    sshd-common/src/test/java/org/apache/sshd/common/config/keys/writer/openssh/OpenSSHKeyPairResourceWriterTest.java
+    sshd-common/src/test/java/org/apache/sshd/common/util/security/eddsa/EDDSAProviderTest.java
+    sshd-common/src/test/java/org/apache/sshd/common/util/security/eddsa/Ed25519VectorsTest.java
+    sshd-common/src/test/java/org/apache/sshd/common/util/security/eddsa/EdDSASecurityProviderRegistrarTest.java
+    sshd-common/src/test/java/org/apache/sshd/server/keyprovider/SimpleGeneratorHostKeyProviderTest.java
+    sshd-common/src/test/java/org/apache/sshd/util/test/CommonTestSupportUtils.java
+
+### Ignored for now
+
+PUTTy windows crap:
+
+    sshd-putty/src/main/java/org/apache/sshd/putty/EdDSAPuttyKeyDecoder.java
+
+Comment only:
+
+    sshd-common/src/main/java/org/apache/sshd/server/keyprovider/SimpleGeneratorHostKeyProvider.java
+
+### POM & Others
+
+    assembly/pom.xml
+    assembly/src/main/legal/notices.xml
+    docs/dependencies.md
+    pom.xml
+    sshd-benchmarks/pom.xml
+    sshd-cli/pom.xml
+    sshd-common/pom.xml
+    sshd-contrib/pom.xml
+    sshd-core/pom.xml
+    sshd-mina/pom.xml
+    sshd-netty/pom.xml
+    sshd-osgi/pom.xml
+    sshd-putty/pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.apache.sshd</groupId>
     <artifactId>sshd</artifactId>
-    <version>2.15.1-SNAPSHOT</version>
+    <version>2.15.88-SNAPSHOT</version>
     <name>Apache Mina SSHD</name>
     <packaging>pom</packaging>
     <inceptionYear>2008</inceptionYear>

--- a/sshd-benchmarks/pom.xml
+++ b/sshd-benchmarks/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.sshd</groupId>
         <artifactId>sshd</artifactId>
-        <version>2.15.1-SNAPSHOT</version>
+        <version>2.15.88-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/sshd-cli/pom.xml
+++ b/sshd-cli/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sshd</groupId>
         <artifactId>sshd</artifactId>
-        <version>2.15.1-SNAPSHOT</version>
+        <version>2.15.88-SNAPSHOT</version>
     </parent>
 
     <artifactId>sshd-cli</artifactId>

--- a/sshd-common/pom.xml
+++ b/sshd-common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sshd</groupId>
         <artifactId>sshd</artifactId>
-        <version>2.15.1-SNAPSHOT</version>
+        <version>2.15.88-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/sshd-common/src/main/filtered-resources/META-INF/services/org.apache.sshd.common.config.keys.KeyTypeSupport-x
+++ b/sshd-common/src/main/filtered-resources/META-INF/services/org.apache.sshd.common.config.keys.KeyTypeSupport-x
@@ -1,0 +1,1 @@
+org.apache.sshd.common.util.security.eddsa.Ed25519JavaProvider

--- a/sshd-common/src/main/java/org/apache/sshd/common/config/keys/KeyTypeSupport.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/config/keys/KeyTypeSupport.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.common.config.keys;
+
+import java.security.GeneralSecurityException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+
+import org.apache.sshd.common.signature.Signature;
+import org.apache.sshd.common.util.buffer.Buffer;
+import org.apache.sshd.common.util.security.SecurityUtils;
+import org.apache.sshd.common.util.security.eddsa.Ed25519JavaProvider;
+
+/**
+ *
+ * @author Pavel Flaska
+ */
+public interface KeyTypeSupport {
+
+    static List<KeyTypeSupport> providers() {
+        List<KeyTypeSupport> providers = new ArrayList<>();
+        ServiceLoader<KeyTypeSupport> instances = ServiceLoader.load(KeyTypeSupport.class);
+        instances.iterator().forEachRemaining(providers::add);
+        if (SecurityUtils.isEDDSACurveSupported()) {
+            providers.add(new Ed25519JavaProvider());
+        }
+        return providers;
+    }
+
+    static KeyTypeSupport getProvider(String keyType) {
+        KeyTypeSupport keyGenUtils = null;
+        for (KeyTypeSupport g : KeyTypeSupport.providers()) {
+            if (g.supports(keyType) && g.available()) {
+                keyGenUtils = g;
+                break;
+            }
+        }
+        if (keyGenUtils != null) {
+            System.out.println(keyGenUtils.getClass());
+        }
+        return keyGenUtils;
+    }
+
+    boolean supports(String keyType);
+
+    boolean available();
+
+    Class<? extends PublicKey> getEDDSAPublicKeyType();
+
+    Class<? extends PrivateKey> getEDDSAPrivateKeyType();
+
+    PublicKey generatePublicKey(byte[] seed) throws GeneralSecurityException;
+
+    PrivateKey generatePrivateKey(byte[] seed) throws GeneralSecurityException;
+
+    PublicKeyEntryDecoder getPublicKeyEntryDecoder();
+
+    PrivateKeyEntryDecoder getPrivateKeyEntryDecoder();
+
+    Signature getSignature();
+
+    Buffer putRawPublicKey(Buffer buffer, PublicKey key);
+
+    boolean compareEDDSAPPublicKeys(PublicKey k1, PublicKey k2);
+
+}

--- a/sshd-common/src/main/java/org/apache/sshd/common/config/keys/KeyUtils.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/config/keys/KeyUtils.java
@@ -183,9 +183,7 @@ public final class KeyUtils {
         if (SecurityUtils.isECCSupported()) {
             registerPublicKeyEntryDecoder(ECDSAPublicKeyEntryDecoder.INSTANCE);
         }
-        if (SecurityUtils.isEDDSACurveSupported()) {
-            registerPublicKeyEntryDecoder(SecurityUtils.getEDDSAPublicKeyEntryDecoder());
-        }
+        KeyTypeSupport.providers().forEach(s -> KeyUtils.registerPublicKeyEntryDecoder(s.getPublicKeyEntryDecoder()));
 
         // order matters, these must be last since they register their PrivateKey type as java.security.PrivateKey
         // there is logical code which discovers a decoder type by instance assignability to this registered type
@@ -193,6 +191,7 @@ public final class KeyUtils {
         if (SecurityUtils.isECCSupported()) {
             registerPublicKeyEntryDecoder(SkECDSAPublicKeyEntryDecoder.INSTANCE);
         }
+        // TODO PF: This should be supported even with JDK-ed25519
         if (SecurityUtils.isEDDSACurveSupported()) {
             registerPublicKeyEntryDecoder(SkED25519PublicKeyEntryDecoder.INSTANCE);
         }

--- a/sshd-common/src/main/java/org/apache/sshd/common/config/keys/loader/openssh/OpenSSHKeyPairResourceParser.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/config/keys/loader/openssh/OpenSSHKeyPairResourceParser.java
@@ -49,6 +49,7 @@ import org.apache.sshd.common.cipher.BuiltinCiphers;
 import org.apache.sshd.common.cipher.CipherFactory;
 import org.apache.sshd.common.config.keys.FilePasswordProvider;
 import org.apache.sshd.common.config.keys.KeyEntryResolver;
+import org.apache.sshd.common.config.keys.KeyTypeSupport;
 import org.apache.sshd.common.config.keys.KeyUtils;
 import org.apache.sshd.common.config.keys.PrivateKeyEntryDecoder;
 import org.apache.sshd.common.config.keys.PublicKeyEntryDecoder;
@@ -88,13 +89,11 @@ public class OpenSSHKeyPairResourceParser extends AbstractKeyPairResourceParser 
     static {
         registerPrivateKeyEntryDecoder(OpenSSHRSAPrivateKeyDecoder.INSTANCE);
         registerPrivateKeyEntryDecoder(OpenSSHDSSPrivateKeyEntryDecoder.INSTANCE);
-
         if (SecurityUtils.isECCSupported()) {
             registerPrivateKeyEntryDecoder(OpenSSHECDSAPrivateKeyEntryDecoder.INSTANCE);
         }
-        if (SecurityUtils.isEDDSACurveSupported()) {
-            registerPrivateKeyEntryDecoder(SecurityUtils.getOpenSSHEDDSAPrivateKeyEntryDecoder());
-        }
+        KeyTypeSupport.providers()
+                .forEach(s -> OpenSSHKeyPairResourceParser.registerPrivateKeyEntryDecoder(s.getPrivateKeyEntryDecoder()));
     }
 
     public OpenSSHKeyPairResourceParser() {

--- a/sshd-common/src/main/java/org/apache/sshd/common/signature/AbstractSignature.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/signature/AbstractSignature.java
@@ -43,6 +43,7 @@ import org.apache.sshd.common.util.security.SecurityUtils;
  * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
 public abstract class AbstractSignature implements Signature {
+    private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
 
     private java.security.Signature signatureInstance;
     private final String algorithm;
@@ -53,6 +54,16 @@ public abstract class AbstractSignature implements Signature {
         this.algorithm = ValidateUtils.checkNotNullAndNotEmpty(algorithm, "No signature algorithm specified");
         this.sshAlgorithmName = ValidateUtils.checkNotNullAndNotEmpty(sshAlgorithmName,
                 "Missing protocol name of the signature algorithm.");
+    }
+
+    public static String bytesToHex(byte[] bytes) {
+        char[] hexChars = new char[bytes.length * 2];
+        for (int j = 0; j < bytes.length; j++) {
+            int v = bytes[j] & 0xFF;
+            hexChars[j * 2] = HEX_ARRAY[v >>> 4];
+            hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
+        }
+        return new String(hexChars);
     }
 
     @Override
@@ -95,7 +106,9 @@ public abstract class AbstractSignature implements Signature {
     @Override
     public byte[] sign(SessionContext session) throws Exception {
         java.security.Signature signature = Objects.requireNonNull(getSignature(), "Signature not initialized");
-        return signature.sign();
+        byte[] sig = signature.sign();
+        System.out.println("Signature: " + bytesToHex(sig));
+        return sig;
     }
 
     @Override

--- a/sshd-common/src/main/java/org/apache/sshd/common/signature/BuiltinSignatures.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/signature/BuiltinSignatures.java
@@ -237,7 +237,7 @@ public enum BuiltinSignatures implements SignatureFactory {
 
         @Override
         public boolean isSupported() {
-            return SecurityUtils.isEDDSACurveSupported();
+            return SecurityUtils.isEdEcJdkAvailable() || SecurityUtils.isEDDSACurveSupported();
         }
     },
     ed25519_cert(KeyPairProvider.SSH_ED25519_CERT) {

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/SecurityUtils.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/SecurityUtils.java
@@ -81,6 +81,7 @@ import org.apache.sshd.common.util.security.bouncycastle.BouncyCastleEncryptedPr
 import org.apache.sshd.common.util.security.bouncycastle.BouncyCastleGeneratorHostKeyProvider;
 import org.apache.sshd.common.util.security.bouncycastle.BouncyCastleKeyPairResourceParser;
 import org.apache.sshd.common.util.security.bouncycastle.BouncyCastleRandomFactory;
+import org.apache.sshd.common.util.security.eddsa.EdDSASecurityProviderUtils;
 import org.apache.sshd.common.util.security.eddsa.generic.EdDSASupport;
 import org.apache.sshd.common.util.threads.ThreadUtils;
 import org.apache.sshd.server.keyprovider.AbstractGeneratorHostKeyProvider;

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/SecurityUtils.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/SecurityUtils.java
@@ -32,7 +32,9 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
+import java.security.Provider.Service;
 import java.security.PublicKey;
+import java.security.Security;
 import java.security.Signature;
 import java.security.cert.CertificateFactory;
 import java.util.Arrays;
@@ -60,6 +62,7 @@ import javax.crypto.spec.DHParameterSpec;
 import org.apache.sshd.common.NamedResource;
 import org.apache.sshd.common.PropertyResolverUtils;
 import org.apache.sshd.common.config.keys.FilePasswordProvider;
+import org.apache.sshd.common.config.keys.KeyTypeSupport;
 import org.apache.sshd.common.config.keys.KeyUtils;
 import org.apache.sshd.common.config.keys.PrivateKeyEntryDecoder;
 import org.apache.sshd.common.config.keys.PublicKeyEntryDecoder;
@@ -284,7 +287,7 @@ public final class SecurityUtils {
                 try {
                     getKeyPairGenerator(KeyUtils.EC_ALGORITHM);
                     hasEcc = Boolean.TRUE;
-                } catch (Throwable t) {
+                } catch (GeneralSecurityException t) {
                     hasEcc = Boolean.FALSE;
                 }
             } else {
@@ -643,6 +646,11 @@ public final class SecurityUtils {
         return Optional.empty();
     }
 
+    public static boolean isEdEcJdkAvailable() {
+        Service ed25519factory = Security.getProvider("SunEC").getService("KeyFactory", "Ed25519");
+        return ed25519factory != null;
+    }
+
     /* -------------------------------------------------------------------- */
 
     public static PublicKeyEntryDecoder<? extends PublicKey, ? extends PrivateKey> getEDDSAPublicKeyEntryDecoder() {
@@ -668,7 +676,30 @@ public final class SecurityUtils {
         if (support.isPresent()) {
             return support.get().getEDDSASigner();
         }
+        throw new UnsupportedOperationException(EDDSA + " Signer not available");
+    }
 
+    public static PublicKeyEntryDecoder<? extends PublicKey, ? extends PrivateKey> getEDDSAPublicKeyEntryDecoderJdk15() {
+        KeyTypeSupport gen = KeyTypeSupport.getProvider(KeyPairProvider.SSH_ED25519);
+        if (gen != null) {
+            return gen.getPublicKeyEntryDecoder();
+        }
+        throw new UnsupportedOperationException(EDDSA + " provider N/A");
+    }
+
+    public static PrivateKeyEntryDecoder<? extends PublicKey, ? extends PrivateKey> getOpenSSHEDDSAPrivateKeyEntryDecoderJdk15() {
+        KeyTypeSupport gen = KeyTypeSupport.getProvider(KeyPairProvider.SSH_ED25519);
+        if (gen != null) {
+            return gen.getPrivateKeyEntryDecoder();
+        }
+        throw new UnsupportedOperationException(EDDSA + " provider N/A");
+    }
+
+    public static org.apache.sshd.common.signature.Signature getEDDSASignerJdk15() {
+        KeyTypeSupport gen = KeyTypeSupport.getProvider(KeyPairProvider.SSH_ED25519);
+        if (gen != null) {
+            return gen.getSignature();
+        }
         throw new UnsupportedOperationException(EDDSA + " Signer not available");
     }
 
@@ -696,6 +727,24 @@ public final class SecurityUtils {
     public static boolean compareEDDSAPPublicKeys(PublicKey k1, PublicKey k2) {
         Optional<EdDSASupport<?, ?>> support = getEdDSASupport();
         return support.map(edDSASupport -> edDSASupport.compareEDDSAPPublicKeys(k1, k2)).orElse(false);
+    }
+
+    public static Class<? extends PublicKey> getEDDSAPublicKeyTypeJdk15() {
+        KeyTypeSupport gen = KeyTypeSupport.getProvider(KeyPairProvider.SSH_ED25519);
+        return gen != null ? gen.getEDDSAPublicKeyType() : PublicKey.class;
+    }
+
+    public static Class<? extends PrivateKey> getEDDSAPrivateKeyTypeJdk15() {
+        KeyTypeSupport gen = KeyTypeSupport.getProvider(KeyPairProvider.SSH_ED25519);
+        return gen != null ? gen.getEDDSAPrivateKeyType() : PrivateKey.class;
+    }
+
+    public static boolean compareEDDSAPPublicKeysJdk15(PublicKey k1, PublicKey k2) {
+        KeyTypeSupport gen = KeyTypeSupport.getProvider(KeyPairProvider.SSH_ED25519);
+        if (gen != null) {
+            return Objects.equals(k1, k2);
+        }
+        return isEDDSACurveSupported() ? EdDSASecurityProviderUtils.compareEDDSAPPublicKeys(k1, k2) : false;
     }
 
     public static boolean compareEDDSAPrivateKeys(PrivateKey k1, PrivateKey k2) {
@@ -745,6 +794,25 @@ public final class SecurityUtils {
         }
 
         return support.get().putRawEDDSAPublicKey(buffer, key);
+    }
+
+    public static PublicKey generateEDDSAPublicKeyJdk15(String keyType, byte[] seed) throws GeneralSecurityException {
+        if (!KeyPairProvider.SSH_ED25519.equals(keyType)) {
+            throw new InvalidKeyException("Unsupported key type: " + keyType);
+        }
+        KeyTypeSupport gen = KeyTypeSupport.getProvider(KeyPairProvider.SSH_ED25519);
+        if (gen != null) {
+            return gen.generatePublicKey(seed);
+        }
+        throw new NoSuchAlgorithmException(EDDSA + " provider not supported");
+    }
+
+    public static <B extends Buffer> B putRawEDDSAPublicKeyJdk15(B buffer, PublicKey key) {
+        KeyTypeSupport gen = KeyTypeSupport.getProvider(KeyPairProvider.SSH_ED25519);
+        if (gen != null) {
+            return (B) gen.putRawPublicKey(buffer, key);
+        }
+        throw new UnsupportedOperationException(EDDSA + " provider not supported");
     }
 
     public static <B extends Buffer> B putEDDSAKeyPair(B buffer, KeyPair kp) {

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/Ed25519JavaProvider.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/Ed25519JavaProvider.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.common.util.security.eddsa;
+
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+
+import net.i2p.crypto.eddsa.EdDSAPrivateKey;
+import net.i2p.crypto.eddsa.EdDSAPublicKey;
+import net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable;
+import net.i2p.crypto.eddsa.spec.EdDSAParameterSpec;
+import net.i2p.crypto.eddsa.spec.EdDSAPrivateKeySpec;
+import net.i2p.crypto.eddsa.spec.EdDSAPublicKeySpec;
+import org.apache.sshd.common.config.keys.KeyTypeSupport;
+import org.apache.sshd.common.config.keys.PrivateKeyEntryDecoder;
+import org.apache.sshd.common.config.keys.PublicKeyEntryDecoder;
+import org.apache.sshd.common.keyprovider.KeyPairProvider;
+import org.apache.sshd.common.signature.Signature;
+import org.apache.sshd.common.util.ValidateUtils;
+import org.apache.sshd.common.util.buffer.Buffer;
+import org.apache.sshd.common.util.security.SecurityUtils;
+
+import static org.apache.sshd.common.util.security.eddsa.EdDSASecurityProviderUtils.CURVE_ED25519_SHA512;
+
+/**
+ *
+ * @author Pavel Flaska
+ */
+public class Ed25519JavaProvider implements KeyTypeSupport {
+
+    public Ed25519JavaProvider() {
+        super();
+    }
+
+    @Override
+    public boolean supports(String keyType) {
+        return KeyPairProvider.SSH_ED25519.equals(keyType);
+    }
+
+    @Override
+    public boolean available() {
+        return SecurityUtils.isEDDSACurveSupported();
+    }
+
+    @Override
+    public Class<? extends PublicKey> getEDDSAPublicKeyType() {
+        return EdDSAPublicKey.class;
+    }
+
+    @Override
+    public Class<? extends PrivateKey> getEDDSAPrivateKeyType() {
+        return EdDSAPrivateKey.class;
+    }
+
+    @Override
+    public PublicKey generatePublicKey(byte[] seed) throws GeneralSecurityException {
+        EdDSAParameterSpec params = EdDSANamedCurveTable.getByName(CURVE_ED25519_SHA512);
+        EdDSAPublicKeySpec keySpec = new EdDSAPublicKeySpec(seed, params);
+        KeyFactory factory = SecurityUtils.getKeyFactory(SecurityUtils.EDDSA);
+
+        return factory.generatePublic(keySpec);
+    }
+
+    @Override
+    public PrivateKey generatePrivateKey(byte[] seed) throws GeneralSecurityException {
+        EdDSAParameterSpec params = EdDSANamedCurveTable.getByName(CURVE_ED25519_SHA512);
+        EdDSAPrivateKeySpec keySpec = new EdDSAPrivateKeySpec(seed, params);
+        KeyFactory factory = SecurityUtils.getKeyFactory(SecurityUtils.EDDSA);
+
+        return factory.generatePrivate(keySpec);
+    }
+
+    @Override
+    public PublicKeyEntryDecoder getPublicKeyEntryDecoder() {
+        return Ed25519PublicKeyDecoder.INSTANCE;
+    }
+
+    @Override
+    public PrivateKeyEntryDecoder getPrivateKeyEntryDecoder() {
+        return OpenSSHEd25519PrivateKeyEntryDecoder.INSTANCE;
+
+    }
+
+    @Override
+    public Signature getSignature() {
+        return EdDSASecurityProviderUtils.getEDDSASignature();
+    }
+
+    @Override
+    public Buffer putRawPublicKey(Buffer buffer, PublicKey key) {
+        ValidateUtils.checkTrue(SecurityUtils.isEDDSACurveSupported(), SecurityUtils.EDDSA + " not supported");
+        EdDSAPublicKey edKey = ValidateUtils.checkInstanceOf(key, EdDSAPublicKey.class, "Not an EDDSA public key: %s", key);
+        byte[] seed = Ed25519PublicKeyDecoder.getSeedValue(edKey);
+        ValidateUtils.checkNotNull(seed, "No seed extracted from key: %s", edKey.getA());
+        buffer.putBytes(seed);
+        return buffer;
+    }
+
+    @Override
+    public boolean compareEDDSAPPublicKeys(PublicKey k1, PublicKey k2) {
+        return EdDSASecurityProviderUtils.compareEDDSAPPublicKeys(k1, k2);
+    }
+
+}

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/Ed25519JavaProvider.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/Ed25519JavaProvider.java
@@ -101,7 +101,9 @@ public class Ed25519JavaProvider implements KeyTypeSupport {
 
     @Override
     public Signature getSignature() {
-        return EdDSASecurityProviderUtils.getEDDSASignature();
+        Signature s = EdDSASecurityProviderUtils.getEDDSASignature();
+        System.out.println("Signature: " + s);
+        return s;
     }
 
     @Override

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/EdDSASecurityProviderUtils.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/EdDSASecurityProviderUtils.java
@@ -36,8 +36,6 @@ import net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable;
 import net.i2p.crypto.eddsa.spec.EdDSAParameterSpec;
 import net.i2p.crypto.eddsa.spec.EdDSAPrivateKeySpec;
 import net.i2p.crypto.eddsa.spec.EdDSAPublicKeySpec;
-import org.apache.sshd.common.config.keys.PrivateKeyEntryDecoder;
-import org.apache.sshd.common.config.keys.PublicKeyEntryDecoder;
 import org.apache.sshd.common.util.ValidateUtils;
 import org.apache.sshd.common.util.buffer.Buffer;
 import org.apache.sshd.common.util.security.SecurityUtils;
@@ -53,14 +51,6 @@ public final class EdDSASecurityProviderUtils {
 
     private EdDSASecurityProviderUtils() {
         throw new UnsupportedOperationException("No instance");
-    }
-
-    public static Class<? extends PublicKey> getEDDSAPublicKeyType() {
-        return EdDSAPublicKey.class;
-    }
-
-    public static Class<? extends PrivateKey> getEDDSAPrivateKeyType() {
-        return EdDSAPrivateKey.class;
     }
 
     public static boolean isEDDSAKey(Key key) {
@@ -119,16 +109,6 @@ public final class EdDSASecurityProviderUtils {
         return SecurityUtils.EDDSA.equalsIgnoreCase(algorithm);
     }
 
-    public static PublicKeyEntryDecoder<? extends PublicKey, ? extends PrivateKey> getEDDSAPublicKeyEntryDecoder() {
-        ValidateUtils.checkTrue(SecurityUtils.isEDDSACurveSupported(), SecurityUtils.EDDSA + " not supported");
-        return Ed25519PublicKeyDecoder.INSTANCE;
-    }
-
-    public static PrivateKeyEntryDecoder<? extends PublicKey, ? extends PrivateKey> getOpenSSHEDDSAPrivateKeyEntryDecoder() {
-        ValidateUtils.checkTrue(SecurityUtils.isEDDSACurveSupported(), SecurityUtils.EDDSA + " not supported");
-        return OpenSSHEd25519PrivateKeyEntryDecoder.INSTANCE;
-    }
-
     public static boolean compareEDDSAPrivateKeys(PrivateKey k1, PrivateKey k2) {
         if (!SecurityUtils.isEDDSACurveSupported()) {
             return false;
@@ -180,15 +160,6 @@ public final class EdDSASecurityProviderUtils {
         EdDSAPrivateKeySpec keySpec = new EdDSAPrivateKeySpec(seed, params);
         KeyFactory factory = SecurityUtils.getKeyFactory(SecurityUtils.EDDSA);
         return factory.generatePrivate(keySpec);
-    }
-
-    public static <B extends Buffer> B putRawEDDSAPublicKey(B buffer, PublicKey key) {
-        ValidateUtils.checkTrue(SecurityUtils.isEDDSACurveSupported(), SecurityUtils.EDDSA + " not supported");
-        EdDSAPublicKey edKey = ValidateUtils.checkInstanceOf(key, EdDSAPublicKey.class, "Not an EDDSA public key: %s", key);
-        byte[] seed = Ed25519PublicKeyDecoder.getSeedValue(edKey);
-        ValidateUtils.checkNotNull(seed, "No seed extracted from key: %s", edKey.getA());
-        buffer.putBytes(seed);
-        return buffer;
     }
 
     public static <B extends Buffer> B putEDDSAKeyPair(B buffer, PublicKey pubKey, PrivateKey prvKey) {

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/EdDSASecurityProviderUtils.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/EdDSASecurityProviderUtils.java
@@ -36,6 +36,8 @@ import net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable;
 import net.i2p.crypto.eddsa.spec.EdDSAParameterSpec;
 import net.i2p.crypto.eddsa.spec.EdDSAPrivateKeySpec;
 import net.i2p.crypto.eddsa.spec.EdDSAPublicKeySpec;
+import org.apache.sshd.common.config.keys.PrivateKeyEntryDecoder;
+import org.apache.sshd.common.config.keys.PublicKeyEntryDecoder;
 import org.apache.sshd.common.util.ValidateUtils;
 import org.apache.sshd.common.util.buffer.Buffer;
 import org.apache.sshd.common.util.security.SecurityUtils;
@@ -51,6 +53,14 @@ public final class EdDSASecurityProviderUtils {
 
     private EdDSASecurityProviderUtils() {
         throw new UnsupportedOperationException("No instance");
+    }
+
+    public static Class<? extends PublicKey> getEDDSAPublicKeyType() {
+        return EdDSAPublicKey.class;
+    }
+
+    public static Class<? extends PrivateKey> getEDDSAPrivateKeyType() {
+        return EdDSAPrivateKey.class;
     }
 
     public static boolean isEDDSAKey(Key key) {
@@ -109,6 +119,16 @@ public final class EdDSASecurityProviderUtils {
         return SecurityUtils.EDDSA.equalsIgnoreCase(algorithm);
     }
 
+    public static PublicKeyEntryDecoder<? extends PublicKey, ? extends PrivateKey> getEDDSAPublicKeyEntryDecoder() {
+        ValidateUtils.checkTrue(SecurityUtils.isEDDSACurveSupported(), SecurityUtils.EDDSA + " not supported");
+        return Ed25519PublicKeyDecoder.INSTANCE;
+    }
+
+    public static PrivateKeyEntryDecoder<? extends PublicKey, ? extends PrivateKey> getOpenSSHEDDSAPrivateKeyEntryDecoder() {
+        ValidateUtils.checkTrue(SecurityUtils.isEDDSACurveSupported(), SecurityUtils.EDDSA + " not supported");
+        return OpenSSHEd25519PrivateKeyEntryDecoder.INSTANCE;
+    }
+
     public static boolean compareEDDSAPrivateKeys(PrivateKey k1, PrivateKey k2) {
         if (!SecurityUtils.isEDDSACurveSupported()) {
             return false;
@@ -160,6 +180,15 @@ public final class EdDSASecurityProviderUtils {
         EdDSAPrivateKeySpec keySpec = new EdDSAPrivateKeySpec(seed, params);
         KeyFactory factory = SecurityUtils.getKeyFactory(SecurityUtils.EDDSA);
         return factory.generatePrivate(keySpec);
+    }
+
+    public static <B extends Buffer> B putRawEDDSAPublicKey(B buffer, PublicKey key) {
+        ValidateUtils.checkTrue(SecurityUtils.isEDDSACurveSupported(), SecurityUtils.EDDSA + " not supported");
+        EdDSAPublicKey edKey = ValidateUtils.checkInstanceOf(key, EdDSAPublicKey.class, "Not an EDDSA public key: %s", key);
+        byte[] seed = Ed25519PublicKeyDecoder.getSeedValue(edKey);
+        ValidateUtils.checkNotNull(seed, "No seed extracted from key: %s", edKey.getA());
+        buffer.putBytes(seed);
+        return buffer;
     }
 
     public static <B extends Buffer> B putEDDSAKeyPair(B buffer, PublicKey pubKey, PrivateKey prvKey) {

--- a/sshd-contrib/pom.xml
+++ b/sshd-contrib/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sshd</groupId>
         <artifactId>sshd</artifactId>
-        <version>2.15.1-SNAPSHOT</version>
+        <version>2.15.88-SNAPSHOT</version>
     </parent>
 
     <!-- NOTE ::: NOTE ::: NOTE ::: NOTE ::: NOTE ::: NOTE ::: NOTE ::: NOTE :::

--- a/sshd-core/pom.xml
+++ b/sshd-core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sshd</groupId>
         <artifactId>sshd</artifactId>
-        <version>2.15.1-SNAPSHOT</version>
+        <version>2.15.88-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/sshd-core/src/main/java/org/apache/sshd/client/auth/pubkey/KeyPairIdentity.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/auth/pubkey/KeyPairIdentity.java
@@ -82,6 +82,8 @@ public class KeyPairIdentity implements PublicKeyIdentity, SignatureFactoriesHol
         verifier.update(session, data);
 
         byte[] signature = verifier.sign(session);
+        //        System.out.println(bytesToHex(signature));
+        //        System.out.println(HexFormat.ofDelimiter(" ").formatHex(signature));
         return new SimpleImmutableEntry<>(factory.getName(), signature);
     }
 

--- a/sshd-git/pom.xml
+++ b/sshd-git/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sshd</groupId>
         <artifactId>sshd</artifactId>
-        <version>2.15.1-SNAPSHOT</version>
+        <version>2.15.88-SNAPSHOT</version>
     </parent>
 
     <artifactId>sshd-git</artifactId>

--- a/sshd-jdk-ed25519/pom.xml
+++ b/sshd-jdk-ed25519/pom.xml
@@ -22,14 +22,13 @@
     <parent>
         <groupId>org.apache.sshd</groupId>
         <artifactId>sshd</artifactId>
-        <version>2.15.88-SNAPSHOT</version>
-        <relativePath>..</relativePath>
+        <version>2.14.88-SNAPSHOT</version>
     </parent>
 
-    <artifactId>sshd-putty</artifactId>
-    <name>Apache Mina SSHD :: Putty key files support utilities</name>
+    <artifactId>sshd-jdk-ed25519</artifactId>
+    <name>Apache Mina SSHD :: jdk-ed25519 support</name>
     <packaging>jar</packaging>
-    <inceptionYear>2018</inceptionYear>
+    <inceptionYear>2024</inceptionYear>
 
     <properties>
         <projectRoot>${project.basedir}/..</projectRoot>
@@ -38,56 +37,42 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.sshd</groupId>
-            <artifactId>sshd-common</artifactId>
+            <artifactId>sshd-core</artifactId>
             <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpg-jdk18on</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk18on</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <!-- For ed25519 support -->
-        <dependency>
-            <groupId>net.i2p.crypto</groupId>
-            <artifactId>eddsa</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <!-- test dependencies -->
-        <dependency>
-            <groupId>org.apache.sshd</groupId>
-            <artifactId>sshd-common</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-junit-jupiter</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+		        <directory>src/main/resources</directory>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
                 <configuration>
-                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                    <reportsDirectory>${project.build.directory}/surefire-reports-putty</reportsDirectory>
+                    <source>jdk17</source>
+                    <target>jdk17</target>
+                    <release>17</release>
+                    <compilerArgument>-g</compilerArgument>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>
             </plugin>
         </plugins>

--- a/sshd-jdk-ed25519/src/main/java/org/apache/sshd/keyprovider/jdk/ed25519/Ed25519BuiltinPublicKeyDecoder.java
+++ b/sshd-jdk-ed25519/src/main/java/org/apache/sshd/keyprovider/jdk/ed25519/Ed25519BuiltinPublicKeyDecoder.java
@@ -95,34 +95,8 @@ public final class Ed25519BuiltinPublicKeyDecoder extends AbstractPublicKeyEntry
         byte[] seed = KeyEntryResolver.readRLEBytes(keyData, 200);
 
         EdECPublicKeySpec keySpec = new EdECPublicKeySpec(
-                NamedParameterSpec.ED25519, byteArrayToEdPoint(seed));
+                NamedParameterSpec.ED25519, EdECBuiltinSecurityProvider.decodeToEdECPoint(seed));
         return (EdECPublicKey) KeyFactory.getInstance("ED25519", "SunEC").generatePublic(keySpec);
-    }
-
-    private static void swap(byte[] arr, int i, int j) {
-        byte tmp = arr[i];
-        arr[i] = arr[j];
-        arr[j] = tmp;
-    }
-
-    private static void reverse(byte[] arr) {
-        int i = 0;
-        int j = arr.length - 1;
-
-        while (i < j) {
-            swap(arr, i, j);
-            i++;
-            j--;
-        }
-    }
-
-    private static EdECPoint byteArrayToEdPoint(byte[] arr) {
-        byte msb = arr[arr.length - 1];
-        boolean xOdd = (msb & 0x80) != 0;
-        arr[arr.length - 1] &= (byte) 0x7F;
-        reverse(arr);
-        BigInteger y = new BigInteger(1, arr);
-        return new EdECPoint(xOdd, y);
     }
 
     public static byte[] getSeedValue(EdECPublicKey key) {

--- a/sshd-jdk-ed25519/src/main/java/org/apache/sshd/keyprovider/jdk/ed25519/Ed25519BuiltinPublicKeyDecoder.java
+++ b/sshd-jdk-ed25519/src/main/java/org/apache/sshd/keyprovider/jdk/ed25519/Ed25519BuiltinPublicKeyDecoder.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.keyprovider.jdk.ed25519;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.math.BigInteger;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.EdECPrivateKey;
+import java.security.interfaces.EdECPublicKey;
+import java.security.spec.EdECPoint;
+import java.security.spec.EdECPrivateKeySpec;
+import java.security.spec.EdECPublicKeySpec;
+import java.security.spec.NamedParameterSpec;
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.sshd.common.config.keys.KeyEntryResolver;
+import org.apache.sshd.common.config.keys.impl.AbstractPublicKeyEntryDecoder;
+import org.apache.sshd.common.keyprovider.KeyPairProvider;
+import org.apache.sshd.common.session.SessionContext;
+import org.apache.sshd.common.util.security.SecurityUtils;
+
+/**
+ *
+ * @author Pavel Flaska
+ */
+public final class Ed25519BuiltinPublicKeyDecoder extends AbstractPublicKeyEntryDecoder<EdECPublicKey, EdECPrivateKey> {
+
+    public static final Ed25519BuiltinPublicKeyDecoder INSTANCE = new Ed25519BuiltinPublicKeyDecoder();
+
+    public Ed25519BuiltinPublicKeyDecoder() {
+        super(EdECPublicKey.class, EdECPrivateKey.class,
+              Collections.unmodifiableList(
+                      Collections.singletonList(
+                              KeyPairProvider.SSH_ED25519)));
+    }
+
+    @Override
+    public EdECPublicKey clonePublicKey(EdECPublicKey key) throws GeneralSecurityException {
+        if (key == null) {
+            return null;
+        } else {
+            return generatePublicKey(new EdECPublicKeySpec(key.getParams(), key.getPoint()));
+        }
+    }
+
+    @Override
+    public EdECPrivateKey clonePrivateKey(EdECPrivateKey key) throws GeneralSecurityException {
+        if (key == null) {
+            return null;
+        } else {
+            return generatePrivateKey(new EdECPrivateKeySpec(key.getParams(), key.getBytes().get()));
+        }
+    }
+
+    @Override
+    public KeyPairGenerator getKeyPairGenerator() throws GeneralSecurityException {
+        return SecurityUtils.getKeyPairGenerator(SecurityUtils.EDDSA);
+    }
+
+    @Override
+    public KeyFactory getKeyFactoryInstance() throws GeneralSecurityException {
+        return SecurityUtils.getKeyFactory(SecurityUtils.EDDSA);
+    }
+
+    @Override
+    public String encodePublicKey(OutputStream s, EdECPublicKey key) throws IOException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public EdECPublicKey decodePublicKey(
+            SessionContext session, String keyType, InputStream keyData, Map<String, String> headers)
+            throws IOException, GeneralSecurityException {
+        byte[] seed = KeyEntryResolver.readRLEBytes(keyData, 200);
+
+        EdECPublicKeySpec keySpec = new EdECPublicKeySpec(
+                NamedParameterSpec.ED25519, byteArrayToEdPoint(seed));
+        return (EdECPublicKey) KeyFactory.getInstance("ED25519", "SunEC").generatePublic(keySpec);
+    }
+
+    private static void swap(byte[] arr, int i, int j) {
+        byte tmp = arr[i];
+        arr[i] = arr[j];
+        arr[j] = tmp;
+    }
+
+    private static void reverse(byte[] arr) {
+        int i = 0;
+        int j = arr.length - 1;
+
+        while (i < j) {
+            swap(arr, i, j);
+            i++;
+            j--;
+        }
+    }
+
+    private static EdECPoint byteArrayToEdPoint(byte[] arr) {
+        byte msb = arr[arr.length - 1];
+        boolean xOdd = (msb & 0x80) != 0;
+        arr[arr.length - 1] &= (byte) 0x7F;
+        reverse(arr);
+        BigInteger y = new BigInteger(1, arr);
+        return new EdECPoint(xOdd, y);
+    }
+
+    public static byte[] getSeedValue(EdECPublicKey key) {
+        return key.getPoint().getY().toByteArray();
+    }
+
+}

--- a/sshd-jdk-ed25519/src/main/java/org/apache/sshd/keyprovider/jdk/ed25519/EdECBuiltinSecurityProvider.java
+++ b/sshd-jdk-ed25519/src/main/java/org/apache/sshd/keyprovider/jdk/ed25519/EdECBuiltinSecurityProvider.java
@@ -31,19 +31,16 @@ import java.security.spec.EdECPoint;
 import java.security.spec.EdECPrivateKeySpec;
 import java.security.spec.EdECPublicKeySpec;
 import java.security.spec.NamedParameterSpec;
-import java.util.Collections;
-import java.util.Map;
 import java.util.Objects;
 
 import org.apache.sshd.common.config.keys.KeyTypeSupport;
 import org.apache.sshd.common.config.keys.PrivateKeyEntryDecoder;
 import org.apache.sshd.common.config.keys.PublicKeyEntryDecoder;
 import org.apache.sshd.common.keyprovider.KeyPairProvider;
-import org.apache.sshd.common.session.SessionContext;
-import org.apache.sshd.common.signature.AbstractSignature;
 import org.apache.sshd.common.signature.Signature;
 import org.apache.sshd.common.util.ValidateUtils;
 import org.apache.sshd.common.util.buffer.Buffer;
+import org.apache.sshd.common.util.security.eddsa.generic.GenericSignatureEd25519;
 
 /**
  *
@@ -107,15 +104,7 @@ public final class EdECBuiltinSecurityProvider implements KeyTypeSupport {
 
     @Override
     public Signature getSignature() {
-        // todo #pf: prototype only!
-        return new AbstractSignature("Ed25519") {
-            @Override
-            public boolean verify(SessionContext session, byte[] sig) throws Exception {
-                Map.Entry<String, byte[]> encoding = extractEncodedSignature(sig, Collections.singleton("ssh-ed25519"));
-
-                return doVerify(encoding.getValue());
-            }
-        };
+        return new GenericSignatureEd25519("Ed25519");
     }
 
     /**

--- a/sshd-jdk-ed25519/src/main/java/org/apache/sshd/keyprovider/jdk/ed25519/EdECBuiltinSecurityProvider.java
+++ b/sshd-jdk-ed25519/src/main/java/org/apache/sshd/keyprovider/jdk/ed25519/EdECBuiltinSecurityProvider.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.keyprovider.jdk.ed25519;
+
+import java.math.BigInteger;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.PublicKey;
+import java.security.Security;
+import java.security.interfaces.EdECPrivateKey;
+import java.security.interfaces.EdECPublicKey;
+import java.security.spec.EdECPoint;
+import java.security.spec.EdECPrivateKeySpec;
+import java.security.spec.EdECPublicKeySpec;
+import java.security.spec.NamedParameterSpec;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.sshd.common.config.keys.KeyTypeSupport;
+import org.apache.sshd.common.config.keys.PrivateKeyEntryDecoder;
+import org.apache.sshd.common.config.keys.PublicKeyEntryDecoder;
+import org.apache.sshd.common.keyprovider.KeyPairProvider;
+import org.apache.sshd.common.session.SessionContext;
+import org.apache.sshd.common.signature.AbstractSignature;
+import org.apache.sshd.common.signature.Signature;
+import org.apache.sshd.common.util.ValidateUtils;
+import org.apache.sshd.common.util.buffer.Buffer;
+
+/**
+ *
+ * @author Pavel Flaska
+ */
+public final class EdECBuiltinSecurityProvider implements KeyTypeSupport {
+
+    /**
+     *
+     */
+    public EdECBuiltinSecurityProvider() {
+        super();
+    }
+
+    @Override
+    public boolean supports(String keyType) {
+        return KeyPairProvider.SSH_ED25519.equals(keyType);
+    }
+
+    @Override
+    public boolean available() {
+        // todo #pf: It can be useful to introduce config property to explicitely
+        // enable/disable provider. Prevent collision.
+        Provider.Service ed25519factory = Security.getProvider("SunEC").getService("KeyFactory", "Ed25519");
+        return ed25519factory != null;
+    }
+
+    @Override
+    public Class<? extends PublicKey> getEDDSAPublicKeyType() {
+        return EdECPublicKey.class;
+    }
+
+    @Override
+    public Class<? extends PrivateKey> getEDDSAPrivateKeyType() {
+        return EdECPrivateKey.class;
+    }
+
+    @Override
+    public PublicKey generatePublicKey(byte[] seed) throws GeneralSecurityException {
+        KeyFactory factory = KeyFactory.getInstance("ED25519", "SunEC");
+        EdECPublicKeySpec keySpec = new EdECPublicKeySpec(NamedParameterSpec.ED25519, decodeToEdECPoint(seed));
+        return factory.generatePublic(keySpec);
+    }
+
+    @Override
+    public PrivateKey generatePrivateKey(byte[] seed) throws GeneralSecurityException {
+        EdECPrivateKeySpec keySpec = new EdECPrivateKeySpec(NamedParameterSpec.ED25519, seed);
+        KeyFactory factory = KeyFactory.getInstance("ED25519", "SunEC");
+        return factory.generatePrivate(keySpec);
+    }
+
+    @Override
+    public PublicKeyEntryDecoder getPublicKeyEntryDecoder() {
+        return Ed25519BuiltinPublicKeyDecoder.INSTANCE;
+    }
+
+    @Override
+    public PrivateKeyEntryDecoder getPrivateKeyEntryDecoder() {
+        return OpenSSHEd25519BuiltinPrivateKeyEntryDecoder.INSTANCE;
+    }
+
+    @Override
+    public Signature getSignature() {
+        // todo #pf: prototype only!
+        return new AbstractSignature("Ed25519") {
+            @Override
+            public boolean verify(SessionContext session, byte[] sig) throws Exception {
+                Map.Entry<String, byte[]> encoding = extractEncodedSignature(sig, Collections.singleton("ssh-ed25519"));
+
+                return doVerify(encoding.getValue());
+            }
+        };
+    }
+
+    /**
+     * Create EdECPoint from open ssh public key bytes.
+     *
+     * @param publicKeyBytes ed25519 OpenSSH public key bytes
+     */
+    static EdECPoint decodeToEdECPoint(byte[] publicKeyBytes) {
+        // The BigInteger input array is assumed to be in big-endian byte-order,
+        // but we've got the input in little-endian representation from open ssh
+        // reader.
+        //
+        // References:
+        // https://datatracker.ietf.org/doc/html/rfc8032#section-5.1.3
+        // https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/math/BigInteger.html#%3Cinit%3E(byte%5B%5D)
+        reverseBytes(publicKeyBytes);
+
+        BigInteger y = new BigInteger(1, publicKeyBytes);
+        // is x-coordinate odd?
+        boolean xOdd = y.testBit(255);
+        //  The y-coordinate is recovered simply by clearing xOdd bit.
+        y = y.clearBit(255);
+
+        return new EdECPoint(xOdd, y);
+    }
+
+    private static void reverseBytes(byte[] keyArray) {
+        int i = 0;
+        int j = keyArray.length - 1;
+
+        while (i < j) {
+            byte tmp = keyArray[i];
+            keyArray[i] = keyArray[j];
+            keyArray[j] = tmp;
+            i++;
+            j--;
+        }
+    }
+
+    @Override
+    public Buffer putRawPublicKey(Buffer buffer, PublicKey key) {
+        EdECPublicKey edKey = ValidateUtils.checkInstanceOf(key, EdECPublicKey.class, "Not an EDDSA public key: %s", key);
+
+        byte[] seed = edKey.getPoint().getY().toByteArray();
+        reverseBytes(seed);
+        buffer.putBytes(seed);
+
+        return buffer;
+    }
+
+    @Override
+    public boolean compareEDDSAPPublicKeys(PublicKey k1, PublicKey k2) {
+        if ((k1 instanceof EdECPublicKey) && (k2 instanceof EdECPublicKey)) {
+            return Objects.equals(k1, k2);
+        } else {
+            return false;
+        }
+    }
+
+}

--- a/sshd-jdk-ed25519/src/main/java/org/apache/sshd/keyprovider/jdk/ed25519/OpenSSHEd25519BuiltinPrivateKeyEntryDecoder.java
+++ b/sshd-jdk-ed25519/src/main/java/org/apache/sshd/keyprovider/jdk/ed25519/OpenSSHEd25519BuiltinPrivateKeyEntryDecoder.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.keyprovider.jdk.ed25519;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.GeneralSecurityException;
+import java.security.InvalidKeyException;
+import java.security.KeyFactory;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.EdECPrivateKey;
+import java.security.interfaces.EdECPublicKey;
+import java.security.spec.EdECPrivateKeySpec;
+import java.security.spec.EdECPublicKeySpec;
+import java.security.spec.NamedParameterSpec;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Locale;
+
+import org.apache.sshd.common.config.keys.FilePasswordProvider;
+import org.apache.sshd.common.config.keys.KeyEntryResolver;
+import org.apache.sshd.common.config.keys.impl.AbstractPrivateKeyEntryDecoder;
+import org.apache.sshd.common.keyprovider.KeyPairProvider;
+import org.apache.sshd.common.session.SessionContext;
+import org.apache.sshd.common.util.GenericUtils;
+import org.apache.sshd.common.util.security.SecurityUtils;
+
+/**
+ *
+ * @author Pavel Flaska
+ */
+public class OpenSSHEd25519BuiltinPrivateKeyEntryDecoder extends AbstractPrivateKeyEntryDecoder<EdECPublicKey, EdECPrivateKey> {
+
+    public static final OpenSSHEd25519BuiltinPrivateKeyEntryDecoder INSTANCE
+            = new OpenSSHEd25519BuiltinPrivateKeyEntryDecoder();
+
+    private static final int PK_SIZE = 32;
+    private static final int SK_SIZE = 32;
+    private static final int KEYPAIR_SIZE = PK_SIZE + SK_SIZE;
+
+    public OpenSSHEd25519BuiltinPrivateKeyEntryDecoder() {
+        super(EdECPublicKey.class, EdECPrivateKey.class,
+              Collections.unmodifiableList(
+                      Collections.singletonList(
+                              KeyPairProvider.SSH_ED25519)));
+    }
+
+    @Override
+    public EdECPublicKey clonePublicKey(EdECPublicKey key) throws GeneralSecurityException {
+        if (key == null) {
+            return null;
+        } else {
+            return generatePublicKey(new EdECPublicKeySpec(key.getParams(), key.getPoint()));
+        }
+    }
+
+    @Override
+    public EdECPrivateKey clonePrivateKey(EdECPrivateKey key) throws GeneralSecurityException {
+        if (key == null) {
+            return null;
+        } else {
+            return generatePrivateKey(new EdECPrivateKeySpec(key.getParams(), key.getBytes().get()));
+        }
+    }
+
+    @Override
+    public KeyPairGenerator getKeyPairGenerator() throws GeneralSecurityException {
+        return SecurityUtils.getKeyPairGenerator(SecurityUtils.EDDSA);
+    }
+
+    @Override
+    public KeyFactory getKeyFactoryInstance() throws GeneralSecurityException {
+        return SecurityUtils.getKeyFactory(SecurityUtils.EDDSA);
+    }
+
+    @Override
+    public EdECPrivateKey decodePrivateKey(
+            SessionContext session, String keyType, FilePasswordProvider passwordProvider, InputStream keyData)
+            throws IOException, GeneralSecurityException {
+        if (!KeyPairProvider.SSH_ED25519.equals(keyType)) {
+            throw new InvalidKeyException("Unsupported key type: " + keyType);
+        }
+
+        if (!SecurityUtils.isEdEcJdkAvailable() && !SecurityUtils.isEDDSACurveSupported()) {
+            throw new NoSuchAlgorithmException(SecurityUtils.EDDSA + " provider not supported");
+        }
+
+        // ed25519 bernstein naming: pk .. public key, sk .. secret key
+        // we expect to find two byte arrays with the following structure (type:size):
+        // [pk:32], [sk:32,pk:32]
+
+        byte[] pk = GenericUtils.EMPTY_BYTE_ARRAY;
+        byte[] keypair = GenericUtils.EMPTY_BYTE_ARRAY;
+        try {
+            pk = KeyEntryResolver.readRLEBytes(keyData, PK_SIZE * 2);
+            keypair = KeyEntryResolver.readRLEBytes(keyData, KEYPAIR_SIZE * 2);
+            if (pk.length != PK_SIZE) {
+                throw new InvalidKeyException(
+                        String.format(Locale.ENGLISH, "Unexpected pk size: %s (expected %s)", pk.length, PK_SIZE));
+            }
+
+            if (keypair.length != KEYPAIR_SIZE) {
+                throw new InvalidKeyException(
+                        String.format(Locale.ENGLISH, "Unexpected keypair size: %s (expected %s)", keypair.length,
+                                KEYPAIR_SIZE));
+            }
+
+            // verify that the keypair contains the expected pk
+            // yes, it's stored redundant, this seems to mimic the output structure of the keypair generation interface
+            if (!Arrays.equals(pk, Arrays.copyOfRange(keypair, SK_SIZE, KEYPAIR_SIZE))) {
+                throw new InvalidKeyException("Keypair did not contain the public key.");
+            }
+
+            byte[] sk = Arrays.copyOf(keypair, SK_SIZE);
+            // EdECPrivateKeySpec params = EdDSANamedCurveTable.getByName(EdDSEdECPrivateKeySpecASecurityProviderUtils.CURVE_ED25519_SHA512);
+            EdECPrivateKey privateKey = generatePrivateKey(new EdECPrivateKeySpec(NamedParameterSpec.ED25519, sk));
+
+            // the private key class contains the calculated public key (Abyte)
+            // pointers to the corresponding code:
+            // EdDSAPrivateKeySpec.EdDSAPrivateKeySpec(byte[], EdDSAParameterSpec): A = spec.getB().scalarMultiply(a);
+            // EdDSAPrivateKey.EdDSAPrivateKey(EdDSAPrivateKeySpec): this.Abyte = this.A.toByteArray();
+
+            // we can now verify the generated pk matches the one we read
+            // if (!Arrays.equals(privateKey., pk)) {
+            //     throw new InvalidKeyException("The provided pk does NOT match the computed pk for the given sk.");
+            // }
+
+            return privateKey;
+        } finally {
+            // get rid of sensitive data a.s.a.p
+            Arrays.fill(pk, (byte) 0);
+            Arrays.fill(keypair, (byte) 0);
+        }
+    }
+}

--- a/sshd-jdk-ed25519/src/main/resources/META-INF/services/org.apache.sshd.common.config.keys.KeyTypeSupport
+++ b/sshd-jdk-ed25519/src/main/resources/META-INF/services/org.apache.sshd.common.config.keys.KeyTypeSupport
@@ -1,0 +1,1 @@
+org.apache.sshd.keyprovider.jdk.ed25519.EdECBuiltinSecurityProvider

--- a/sshd-jdk-ed25519/src/test/java/org/apache/sshd/keyprovider/jdk/ed25519/EdECBuiltinSecurityProviderTest.java
+++ b/sshd-jdk-ed25519/src/test/java/org/apache/sshd/keyprovider/jdk/ed25519/EdECBuiltinSecurityProviderTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.keyprovider.jdk.ed25519;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+
+import org.apache.sshd.common.signature.Signature;
+import org.apache.sshd.common.util.buffer.ByteArrayBuffer;
+import org.junit.jupiter.api.Test;
+
+public class EdECBuiltinSecurityProviderTest {
+
+    @Test
+    public void testSignVerifyRoundTrip() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("Ed25519");
+        KeyPair kp = kpg.generateKeyPair();
+        byte[] message = "hello".getBytes(StandardCharsets.UTF_8);
+
+        EdECBuiltinSecurityProvider provider = new EdECBuiltinSecurityProvider();
+        Signature signer = provider.getSignature();
+        signer.initSigner(null, kp.getPrivate());
+        signer.update(null, message);
+        byte[] sig = signer.sign(null);
+
+        ByteArrayBuffer buf = new ByteArrayBuffer();
+        buf.putString("ssh-ed25519");
+        buf.putBytes(sig);
+        byte[] encoded = buf.getCompactData();
+
+        Signature verifier = provider.getSignature();
+        verifier.initVerifier(null, kp.getPublic());
+        verifier.update(null, message);
+        assertTrue(verifier.verify(null, encoded));
+
+        verifier = provider.getSignature();
+        verifier.initVerifier(null, kp.getPublic());
+        verifier.update(null, message);
+        assertTrue(verifier.verify(null, sig));
+    }
+}

--- a/sshd-ldap/pom.xml
+++ b/sshd-ldap/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sshd</groupId>
         <artifactId>sshd</artifactId>
-        <version>2.15.1-SNAPSHOT</version>
+        <version>2.15.88-SNAPSHOT</version>
     </parent>
 
     <artifactId>sshd-ldap</artifactId>

--- a/sshd-mina/pom.xml
+++ b/sshd-mina/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sshd</groupId>
         <artifactId>sshd</artifactId>
-        <version>2.15.1-SNAPSHOT</version>
+        <version>2.15.88-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/sshd-netty/pom.xml
+++ b/sshd-netty/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sshd</groupId>
         <artifactId>sshd</artifactId>
-        <version>2.15.1-SNAPSHOT</version>
+        <version>2.15.88-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/sshd-openpgp/pom.xml
+++ b/sshd-openpgp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sshd</groupId>
         <artifactId>sshd</artifactId>
-        <version>2.15.1-SNAPSHOT</version>
+        <version>2.15.88-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/sshd-osgi/pom.xml
+++ b/sshd-osgi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.sshd</groupId>
         <artifactId>sshd</artifactId>
-        <version>2.15.1-SNAPSHOT</version>
+        <version>2.15.88-SNAPSHOT</version>
     </parent>
 
     <artifactId>sshd-osgi</artifactId>

--- a/sshd-scp/pom.xml
+++ b/sshd-scp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sshd</groupId>
         <artifactId>sshd</artifactId>
-        <version>2.15.1-SNAPSHOT</version>
+        <version>2.15.88-SNAPSHOT</version>
     </parent>
 
     <artifactId>sshd-scp</artifactId>

--- a/sshd-sftp/pom.xml
+++ b/sshd-sftp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sshd</groupId>
         <artifactId>sshd</artifactId>
-        <version>2.15.1-SNAPSHOT</version>
+        <version>2.15.88-SNAPSHOT</version>
     </parent>
 
     <artifactId>sshd-sftp</artifactId>

--- a/sshd-spring-sftp/pom.xml
+++ b/sshd-spring-sftp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sshd</groupId>
         <artifactId>sshd</artifactId>
-        <version>2.15.1-SNAPSHOT</version>
+        <version>2.15.88-SNAPSHOT</version>
     </parent>
 
     <artifactId>sshd-spring-sftp</artifactId>


### PR DESCRIPTION
## Summary
- Use JDK GenericSignatureEd25519 for signing and verifying
- Add round-trip sign/verify test for built-in provider

## Testing
- `mvn -q -pl sshd-jdk-ed25519 -am test` *(fails: Non-resolvable parent POM: org.apache:apache:pom:34 could not be transferred)*

------
https://chatgpt.com/codex/tasks/task_e_6895df892bb8832d8d3d880e538cf4c2
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switched Ed25519 signature handling to use the JDK GenericSignatureEd25519 class for signing and verifying, simplifying the implementation.

- **Testing**
 - Added a round-trip sign and verify test for the built-in provider.

<!-- End of auto-generated description by cubic. -->

